### PR TITLE
Refresh Access Token Before Making API Calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,7 +203,11 @@ def google_access_token(request):
     logged_user = get_logged_user(cookie)
     refresh_token = logged_user.refresh_token
     oauth = get_google_auth()
-    return oauth.refresh_token(Auth.TOKEN_URI, refresh_token=refresh_token)
+    extra = {
+        'client_id': Auth.CLIENT_ID,
+        'client_secret': Auth.CLIENT_SECRET,
+    }
+    return oauth.refresh_token(Auth.TOKEN_URI, refresh_token=refresh_token, **extra)
 
 
 @app.route('/check_session/<cookie>')

--- a/app.py
+++ b/app.py
@@ -96,7 +96,6 @@ class User(db.Model, UserMixin):
     email = db.Column(db.String(100), primary_key=True)
     name = db.Column(db.String(100), nullable=True)
     avatar = db.Column(db.String(200))
-    access_token = db.Column(db.String(5000))
     refresh_token = db.Column(db.String(5000))
     tokens = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow())
@@ -435,7 +434,6 @@ def callback():
             user.name = user_data['name']
             print(token)
             user.tokens = json.dumps(token)
-            user.access_token = token['access_token']
             user.refresh_token = token['refresh_token']
             user.avatar = user_data['picture']
             db.session.add(user)

--- a/app.py
+++ b/app.py
@@ -24,11 +24,7 @@ import ssl
 from urllib import urlencode, urlopen
 import urllib2
 
-import logging
-
 basedir = os.path.abspath(os.path.dirname(__file__))
-log = logging.getLogger()
-log.setLevel(logging.DEBUG)
 
 
 """App Configuration"""

--- a/app.py
+++ b/app.py
@@ -22,7 +22,11 @@ import ssl
 from urllib import urlencode, urlopen
 import urllib2
 
+import logging
+
 basedir = os.path.abspath(os.path.dirname(__file__))
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
 
 
 """App Configuration"""
@@ -207,7 +211,8 @@ def google_access_token(request):
         'client_id': Auth.CLIENT_ID,
         'client_secret': Auth.CLIENT_SECRET,
     }
-    return oauth.refresh_token(Auth.TOKEN_URI, refresh_token=refresh_token, **extra)
+    resp = oauth.refresh_token(Auth.TOKEN_URI, refresh_token=refresh_token, **extra)
+    return resp['access_token']
 
 
 @app.route('/check_session/<cookie>')


### PR DESCRIPTION
#5

When making FireCloud calls, get a new access token, using the refresh token.

Store the refresh token in the database along with the access token. For now, keep the original access in the database, as we only use that one for identity.