### PR TITLE
Content type fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -300,7 +300,7 @@ def proxy_firecloud():
         return "Error getting access token", 401
     url = "{}{}".format(os.getenv('FIRECLOUD_API_BASE', 'https://api.firecloud.org'), pathParam)
     headers = {'Authorization': 'Bearer {}'.format(access_token)}
-    for header in ['Accept', 'Accept-Language']:
+    for header in ['Accept', 'Accept-Language', 'Accept-Encoding']:
         val = request.headers[header]
         if val is not None:
             headers[header] = val
@@ -309,9 +309,10 @@ def proxy_firecloud():
         handler = urllib2.urlopen(req)
         content_type = handler.headers['content-type']
         response = Response(handler.read(), mimetype=content_type)
-        content_encoding = handler.headers['content-encoding']
-        if content_encoding is not None:
-            response.headers['content-encoding'] = content_encoding
+        content_encoding = 'content-encoding'
+        if content_encoding in handler.headers.keys():
+            response.headers[content_encoding] = handler.headers[
+                content_encoding]
         return response
     except urllib2.HTTPError as e:
         resp = {'url': url, 'headers': headers}

--- a/app.py
+++ b/app.py
@@ -211,6 +211,20 @@ def new_google_access_token(request):
     resp = oauth.refresh_token(Auth.TOKEN_URI, refresh_token=refresh_token, **extra)
     return resp['access_token']
 
+def make_request(url, headers):
+    try:
+        req = urllib2.Request(url, headers=headers)
+        handler = urllib2.urlopen(req)
+        content_type = handler.headers['content-type']
+        response = Response(handler.read(), mimetype=content_type)
+        content_encoding = 'content-encoding'
+        if content_encoding in handler.headers.keys():
+            response.headers[content_encoding] = handler.headers[
+                content_encoding]
+        return response
+    except urllib2.HTTPError as e:
+        return e.message, e.code
+
 @app.route('/check_session/<cookie>')
 def check_session(cookie):
     if not request.headers.get("Authorization", None):
@@ -273,19 +287,13 @@ def export_to_firecloud():
         access_token = new_google_access_token(request)
     except OAuth2Error as e:
         return "Error getting access token", 401
-    try:
-        params = urlencode({'workspace': workspace, 'namespace': namespace, 'filters': filters})
-        url = "{}://{}/repository/files/export/firecloud?{}".format(os.getenv('DCC_DASHBOARD_PROTOCOL'),
-                                                                    os.getenv('DCC_DASHBOARD_HOST'),params)
-        req = urllib2.Request(url, headers={'Authorization': "Bearer {}".format(access_token)})
-        handler = urllib2.urlopen(req)
-        content_type = handler.headers['content-type']
-        return Response(handler.read(), mimetype=content_type)
-    except AssertionError as e:
-        response = {
-            'error': e.message
-        }
-        return jsonify(response)
+    params = urlencode(
+        {'workspace': workspace, 'namespace': namespace, 'filters': filters})
+    url = "{}://{}/repository/files/export/firecloud?{}".format(
+        os.getenv('DCC_DASHBOARD_PROTOCOL'),
+        os.getenv('DCC_DASHBOARD_HOST'), params)
+    headers = {'Authorization': "Bearer {}".format(access_token)}
+    return make_request(url, headers)
 
 @app.route('/proxy_firecloud', methods=['GET'])
 @login_required
@@ -304,20 +312,7 @@ def proxy_firecloud():
         val = request.headers[header]
         if val is not None:
             headers[header] = val
-    try:
-        req = urllib2.Request(url, headers=headers)
-        handler = urllib2.urlopen(req)
-        content_type = handler.headers['content-type']
-        response = Response(handler.read(), mimetype=content_type)
-        content_encoding = 'content-encoding'
-        if content_encoding in handler.headers.keys():
-            response.headers[content_encoding] = handler.headers[
-                content_encoding]
-        return response
-    except urllib2.HTTPError as e:
-        resp = {'url': url, 'headers': headers}
-        return jsonify(resp), e.code
-
+    return make_request(url, headers)
 
 @app.route('/<name>.html')
 def html_rend(name):

--- a/app.py
+++ b/app.py
@@ -278,8 +278,9 @@ def export_to_firecloud():
         url = "{}://{}/repository/files/export/firecloud?{}".format(os.getenv('DCC_DASHBOARD_PROTOCOL'),
                                                                     os.getenv('DCC_DASHBOARD_HOST'),params)
         req = urllib2.Request(url, headers={'Authorization': "Bearer {}".format(access_token)})
-        response = urllib2.urlopen(req)
-        return response.read()
+        handler = urllib2.urlopen(req)
+        content_type = handler.headers['content-type']
+        return Response(handler.read(), mimetype=content_type)
     except AssertionError as e:
         response = {
             'error': e.message
@@ -305,8 +306,13 @@ def proxy_firecloud():
             headers[header] = val
     try:
         req = urllib2.Request(url, headers=headers)
-        response = urllib2.urlopen(req)
-        return response.read()
+        handler = urllib2.urlopen(req)
+        content_type = handler.headers['content-type']
+        response = Response(handler.read(), mimetype=content_type)
+        content_encoding = handler.headers['content-encoding']
+        if content_encoding is not None:
+            response.headers['content-encoding'] = content_encoding
+        return response
     except urllib2.HTTPError as e:
         resp = {'url': url, 'headers': headers}
         return jsonify(resp), e.code


### PR DESCRIPTION
When proxying calls to FireCloud, we were not passing through the headers returned by FireCloud, so the response did not have the Content-type header set to application/json.

As part of this, made a `make_request` method to avoid duplication that was happening in the call made to the bagit lambda.

Also, pass on the Accept-Encoding header, so if the browser requests gzip, it will get a gzip response.